### PR TITLE
Fixes and tests

### DIFF
--- a/tests/plugin-event-deleted.test.ts
+++ b/tests/plugin-event-deleted.test.ts
@@ -36,39 +36,9 @@ describe('plugin - event delete & patch history disabled', () => {
     await mongoose.connection.collection('history').deleteMany({})
   })
 
-  it('should deleteMany and emit two delete events', async () => {
-    const users = await User.create([
-      { name: 'John', role: 'user' },
-      { name: 'Alice', role: 'user' },
-      { name: 'Bob', role: 'admin' }
-    ])
-
-    const [john, alice] = users
-
-    await User.deleteMany({ role: 'user' }).exec()
-
-    const history = await History.find({})
-    expect(history).toHaveLength(0)
-
-    expect(em.emit).toHaveBeenCalledTimes(2)
-    expect(em.emit).toHaveBeenCalledWith(USER_DELETED, {
-      oldDoc: expect.objectContaining(john.toObject({ depopulate: true }))
-    })
-    expect(em.emit).toHaveBeenCalledWith(USER_DELETED, {
-      oldDoc: expect.objectContaining(alice.toObject({ depopulate: true }))
-    })
-  })
-
-  it('should deleteMany and emit one delete event { single: true }', async () => {
-    const users = await User.create([
-      { name: 'John', role: 'user' },
-      { name: 'Alice', role: 'user' },
-      { name: 'Bob', role: 'admin' }
-    ])
-
-    const [john] = users
-
-    await User.deleteMany({ role: 'user' }, { single: true }).exec()
+  it('should remove() and emit one delete event', async () => {
+    const john = await User.create({ name: 'John', role: 'user' })
+    await john.remove()
 
     const history = await History.find({})
     expect(history).toHaveLength(0)
@@ -79,107 +49,7 @@ describe('plugin - event delete & patch history disabled', () => {
     })
   })
 
-  it('should deleteOne and emit one delete event', async () => {
-    const users = await User.create([
-      { name: 'John', role: 'user' },
-      { name: 'Alice', role: 'user' },
-      { name: 'Bob', role: 'admin' }
-    ])
-
-    const [john] = users
-
-    await User.deleteOne({ role: 'user' }).exec()
-
-    const history = await History.find({})
-    expect(history).toHaveLength(0)
-
-    expect(em.emit).toHaveBeenCalledTimes(1)
-    expect(em.emit).toHaveBeenCalledWith(USER_DELETED, {
-      oldDoc: expect.objectContaining(john.toObject({ depopulate: true }))
-    })
-  })
-
-  it('should findByIdAndDelete and emit one delete event', async () => {
-    const users = await User.create([
-      { name: 'John', role: 'user' },
-      { name: 'Alice', role: 'user' },
-      { name: 'Bob', role: 'admin' }
-    ])
-
-    const [john] = users
-
-    await User.findByIdAndDelete(john._id).exec()
-
-    const history = await History.find({})
-    expect(history).toHaveLength(0)
-
-    expect(em.emit).toHaveBeenCalledTimes(1)
-    expect(em.emit).toHaveBeenCalledWith(USER_DELETED, {
-      oldDoc: expect.objectContaining(john.toObject({ depopulate: true }))
-    })
-  })
-
-  it('should findByIdAndRemove and emit one delete event', async () => {
-    const users = await User.create([
-      { name: 'John', role: 'user' },
-      { name: 'Alice', role: 'user' },
-      { name: 'Bob', role: 'admin' }
-    ])
-
-    const [john] = users
-
-    await User.findByIdAndRemove(john._id).exec()
-
-    const history = await History.find({})
-    expect(history).toHaveLength(0)
-
-    expect(em.emit).toHaveBeenCalledTimes(1)
-    expect(em.emit).toHaveBeenCalledWith(USER_DELETED, {
-      oldDoc: expect.objectContaining(john.toObject({ depopulate: true }))
-    })
-  })
-
-  it('should findOneAndDelete and emit one delete event', async () => {
-    const users = await User.create([
-      { name: 'John', role: 'user' },
-      { name: 'Alice', role: 'user' },
-      { name: 'Bob', role: 'admin' }
-    ])
-
-    const [john] = users
-
-    await User.findOneAndDelete({ role: 'user' }).exec()
-
-    const history = await History.find({})
-    expect(history).toHaveLength(0)
-
-    expect(em.emit).toHaveBeenCalledTimes(1)
-    expect(em.emit).toHaveBeenCalledWith(USER_DELETED, {
-      oldDoc: expect.objectContaining(john.toObject({ depopulate: true }))
-    })
-  })
-
-  it('should findOneAndRemove and emit one delete event', async () => {
-    const users = await User.create([
-      { name: 'John', role: 'user' },
-      { name: 'Alice', role: 'user' },
-      { name: 'Bob', role: 'admin' }
-    ])
-
-    const [john] = users
-
-    await User.findOneAndRemove({ role: 'user' }).exec()
-
-    const history = await History.find({})
-    expect(history).toHaveLength(0)
-
-    expect(em.emit).toHaveBeenCalledTimes(1)
-    expect(em.emit).toHaveBeenCalledWith(USER_DELETED, {
-      oldDoc: expect.objectContaining(john.toObject({ depopulate: true }))
-    })
-  })
-
-  it('should remove and emit two delete events', async () => {
+  it('should remove() and emit two delete events', async () => {
     const users = await User.create([
       { name: 'John', role: 'user' },
       { name: 'Alice', role: 'user' },
@@ -206,7 +76,7 @@ describe('plugin - event delete & patch history disabled', () => {
     })
   })
 
-  it('should remove and emit one delete event { single: true }', async () => {
+  it('should remove() and emit one delete event { single: true }', async () => {
     const users = await User.create([
       { name: 'John', role: 'user' },
       { name: 'Alice', role: 'user' },
@@ -226,9 +96,16 @@ describe('plugin - event delete & patch history disabled', () => {
     })
   })
 
-  it('should create then delete and emit one delete event', async () => {
-    const john = await User.create({ name: 'John', role: 'user' })
-    await john.delete()
+  it('should findOneAndDelete() and emit one delete event', async () => {
+    const users = await User.create([
+      { name: 'John', role: 'user' },
+      { name: 'Alice', role: 'user' },
+      { name: 'Bob', role: 'admin' }
+    ])
+
+    const [john] = users
+
+    await User.findOneAndDelete({ role: 'user' }).exec()
 
     const history = await History.find({})
     expect(history).toHaveLength(0)
@@ -239,9 +116,132 @@ describe('plugin - event delete & patch history disabled', () => {
     })
   })
 
-  it('should create then remove and emit one delete event', async () => {
+  it('should findOneAndRemove() and emit one delete event', async () => {
+    const users = await User.create([
+      { name: 'John', role: 'user' },
+      { name: 'Alice', role: 'user' },
+      { name: 'Bob', role: 'admin' }
+    ])
+
+    const [john] = users
+
+    await User.findOneAndRemove({ role: 'user' }).exec()
+
+    const history = await History.find({})
+    expect(history).toHaveLength(0)
+
+    expect(em.emit).toHaveBeenCalledTimes(1)
+    expect(em.emit).toHaveBeenCalledWith(USER_DELETED, {
+      oldDoc: expect.objectContaining(john.toObject({ depopulate: true }))
+    })
+  })
+
+  it('should findByIdAndDelete() and emit one delete event', async () => {
+    const users = await User.create([
+      { name: 'John', role: 'user' },
+      { name: 'Alice', role: 'user' },
+      { name: 'Bob', role: 'admin' }
+    ])
+
+    const [john] = users
+
+    await User.findByIdAndDelete(john._id).exec()
+
+    const history = await History.find({})
+    expect(history).toHaveLength(0)
+
+    expect(em.emit).toHaveBeenCalledTimes(1)
+    expect(em.emit).toHaveBeenCalledWith(USER_DELETED, {
+      oldDoc: expect.objectContaining(john.toObject({ depopulate: true }))
+    })
+  })
+
+  it('should findByIdAndRemove() and emit one delete event', async () => {
+    const users = await User.create([
+      { name: 'John', role: 'user' },
+      { name: 'Alice', role: 'user' },
+      { name: 'Bob', role: 'admin' }
+    ])
+
+    const [john] = users
+
+    await User.findByIdAndRemove(john._id).exec()
+
+    const history = await History.find({})
+    expect(history).toHaveLength(0)
+
+    expect(em.emit).toHaveBeenCalledTimes(1)
+    expect(em.emit).toHaveBeenCalledWith(USER_DELETED, {
+      oldDoc: expect.objectContaining(john.toObject({ depopulate: true }))
+    })
+  })
+
+  it('should deleteOne() and emit one delete event', async () => {
+    const users = await User.create([
+      { name: 'John', role: 'user' },
+      { name: 'Alice', role: 'user' },
+      { name: 'Bob', role: 'admin' }
+    ])
+
+    const [john] = users
+
+    await User.deleteOne({ role: 'user' }).exec()
+
+    const history = await History.find({})
+    expect(history).toHaveLength(0)
+
+    expect(em.emit).toHaveBeenCalledTimes(1)
+    expect(em.emit).toHaveBeenCalledWith(USER_DELETED, {
+      oldDoc: expect.objectContaining(john.toObject({ depopulate: true }))
+    })
+  })
+
+  it('should deleteMany() and emit two delete events', async () => {
+    const users = await User.create([
+      { name: 'John', role: 'user' },
+      { name: 'Alice', role: 'user' },
+      { name: 'Bob', role: 'admin' }
+    ])
+
+    const [john, alice] = users
+
+    await User.deleteMany({ role: 'user' }).exec()
+
+    const history = await History.find({})
+    expect(history).toHaveLength(0)
+
+    expect(em.emit).toHaveBeenCalledTimes(2)
+    expect(em.emit).toHaveBeenCalledWith(USER_DELETED, {
+      oldDoc: expect.objectContaining(john.toObject({ depopulate: true }))
+    })
+    expect(em.emit).toHaveBeenCalledWith(USER_DELETED, {
+      oldDoc: expect.objectContaining(alice.toObject({ depopulate: true }))
+    })
+  })
+
+  it('should deleteMany() and emit one delete event { single: true }', async () => {
+    const users = await User.create([
+      { name: 'John', role: 'user' },
+      { name: 'Alice', role: 'user' },
+      { name: 'Bob', role: 'admin' }
+    ])
+
+    const [john] = users
+
+    await User.deleteMany({ role: 'user' }, { single: true }).exec()
+
+    const history = await History.find({})
+    expect(history).toHaveLength(0)
+
+    expect(em.emit).toHaveBeenCalledTimes(1)
+    expect(em.emit).toHaveBeenCalledWith(USER_DELETED, {
+      oldDoc: expect.objectContaining(john.toObject({ depopulate: true }))
+    })
+  })
+
+  it('should create then delete and emit one delete event', async () => {
     const john = await User.create({ name: 'John', role: 'user' })
-    await john.remove()
+    await john.delete()
 
     const history = await History.find({})
     expect(history).toHaveLength(0)

--- a/tests/plugin-event-updated.test.ts
+++ b/tests/plugin-event-updated.test.ts
@@ -1,4 +1,4 @@
-import mongoose, { model } from 'mongoose'
+import mongoose, { Types, model } from 'mongoose'
 
 import UserSchema from './schemas/UserSchema'
 import { patchHistoryPlugin } from '../src/plugin'
@@ -126,7 +126,7 @@ describe('plugin - event updated & patch history disabled', () => {
     expect(em.emit).toHaveBeenCalledWith(USER_UPDATED, {
       oldDoc: expect.objectContaining({
         __v: 0,
-        _id: expect.any(mongoose.Types.ObjectId),
+        _id: expect.any(Types.ObjectId),
         name: 'Bob',
         role: 'user',
         createdAt: expect.any(Date),
@@ -134,7 +134,7 @@ describe('plugin - event updated & patch history disabled', () => {
       }),
       doc: expect.objectContaining({
         __v: 0,
-        _id: expect.any(mongoose.Types.ObjectId),
+        _id: expect.any(Types.ObjectId),
         name: 'Bob Doe',
         role: 'manager',
         createdAt: expect.any(Date),

--- a/tests/plugin-event-updated.test.ts
+++ b/tests/plugin-event-updated.test.ts
@@ -37,7 +37,7 @@ describe('plugin - event updated & patch history disabled', () => {
     await mongoose.connection.collection('history').deleteMany({})
   })
 
-  it('should save/save and emit one update event', async () => {
+  it('should save() and emit one update event', async () => {
     await User.create({ name: 'Bob', role: 'user' })
     const user = new User({ name: 'John', role: 'user' })
     const created = await user.save()
@@ -74,7 +74,134 @@ describe('plugin - event updated & patch history disabled', () => {
     })
   })
 
-  it('should findOneAndReplace and emit one update event', async () => {
+  it('should update() and emit three update event', async () => {
+    await User.create([
+      { name: 'Alice', role: 'user' },
+      { name: 'Bob', role: 'user' },
+      { name: 'John', role: 'user' }
+    ], { ordered: true })
+
+    await User.update({ role: 'user' }, { role: 'manager' })
+    const users = await User.find({ role: 'manager' })
+    expect(users).toHaveLength(3)
+
+    const history = await History.find({})
+    expect(history).toHaveLength(0)
+
+    expect(em.emit).toHaveBeenCalledTimes(3)
+  })
+
+  it('should updateOne() and emit one update event', async () => {
+    await User.create([
+      { name: 'Alice', role: 'user' },
+      { name: 'Bob', role: 'user' },
+      { name: 'John', role: 'user' }
+    ], { ordered: true })
+
+    await User.updateOne({ name: 'Bob' }, { role: 'manager' })
+    const users = await User.find({ role: 'manager' })
+    expect(users).toHaveLength(1)
+
+    const history = await History.find({})
+    expect(history).toHaveLength(0)
+
+    expect(em.emit).toHaveBeenCalledTimes(1)
+  })
+
+  it('should replaceOne() and emit two update event', async () => {
+    await User.create([
+      { name: 'Alice', role: 'user' },
+      { name: 'Bob', role: 'user' },
+      { name: 'John', role: 'user' }
+    ], { ordered: true })
+
+    await User.replaceOne({ name: 'Bob' }, { name: 'Bob Doe', role: 'manager' })
+    const users = await User.find({ role: 'manager' })
+    expect(users).toHaveLength(1)
+
+    const history = await History.find({})
+    expect(history).toHaveLength(0)
+
+    expect(em.emit).toHaveBeenCalledTimes(1)
+    expect(em.emit).toHaveBeenCalledWith(USER_UPDATED, {
+      oldDoc: expect.objectContaining({
+        __v: 0,
+        _id: expect.any(mongoose.Types.ObjectId),
+        name: 'Bob',
+        role: 'user',
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date)
+      }),
+      doc: expect.objectContaining({
+        __v: 0,
+        _id: expect.any(mongoose.Types.ObjectId),
+        name: 'Bob Doe',
+        role: 'manager',
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date)
+      }),
+      patch: expect.arrayContaining([
+        { op: 'test', path: '/name', value: 'Bob' },
+        { op: 'replace', path: '/name', value: 'Bob Doe' },
+        { op: 'test', path: '/role', value: 'user' },
+        { op: 'replace', path: '/role', value: 'manager' }
+      ])
+    })
+  })
+
+  it('should updateMany() and emit two update event', async () => {
+    await User.create([
+      { name: 'Alice', role: 'user' },
+      { name: 'Bob', role: 'user' },
+      { name: 'John', role: 'user' }
+    ], { ordered: true })
+
+    await User.updateMany({ role: 'user' }, { role: 'manager' })
+    const users = await User.find({ role: 'manager' })
+    expect(users).toHaveLength(3)
+
+    const history = await History.find({})
+    expect(history).toHaveLength(0)
+
+    expect(em.emit).toHaveBeenCalledTimes(3)
+  })
+
+  it('should findOneAndUpdate() and emit one update event', async () => {
+    await User.create({ name: 'Bob', role: 'user' })
+    const created = await User.create({ name: 'John', role: 'user' })
+    await User.findOneAndUpdate({ _id: created._id }, { name: 'John Doe', role: 'manager' })
+    const updated = await User.findById(created._id).exec()
+    expect(updated).not.toBeNull()
+
+    const history = await History.find({})
+    expect(history).toHaveLength(0)
+
+    expect(em.emit).toHaveBeenCalledTimes(1)
+    expect(em.emit).toHaveBeenCalledWith(USER_UPDATED, {
+      oldDoc: expect.objectContaining({
+        __v: 0,
+        _id: created._id,
+        name: created.name,
+        role: created.role,
+        createdAt: created.createdAt
+      }),
+      doc: expect.objectContaining({
+        __v: 0,
+        _id: updated?._id,
+        name: updated?.name,
+        role: updated?.role,
+        createdAt: created.createdAt
+      }),
+      patch: expect.arrayContaining([
+        { op: 'test', path: '/role', value: 'user' },
+        { op: 'replace', path: '/role', value: 'manager' },
+        { op: 'test', path: '/name', value: 'John' },
+        { op: 'replace', path: '/name', value: 'John Doe' }
+      ])
+    })
+  })
+
+  it('should findOneAndReplace() and emit one update event', async () => {
     await User.create({ name: 'Bob', role: 'user' })
     const created = await User.create({ name: 'John', role: 'user' })
     await User.findOneAndReplace({ _id: created._id }, { name: 'John Doe', role: 'manager' })
@@ -111,12 +238,9 @@ describe('plugin - event updated & patch history disabled', () => {
     })
   })
 
-  it('should findOneAndUpdate and emit one update event', async () => {
-    await User.create({ name: 'Bob', role: 'user' })
-    const created = await User.create({ name: 'John', role: 'user' })
-    await User.findOneAndUpdate({ _id: created._id }, { name: 'John Doe', role: 'manager' })
-    const updated = await User.findById(created._id).exec()
-    expect(updated).not.toBeNull()
+  it('should findByIdAndUpdate() and emit one update event', async () => {
+    const created = await User.create({ name: 'Bob', role: 'user' })
+    await User.findByIdAndUpdate(created._id, { name: 'John Doe', role: 'manager' })
 
     const history = await History.find({})
     expect(history).toHaveLength(0)
@@ -132,16 +256,16 @@ describe('plugin - event updated & patch history disabled', () => {
       }),
       doc: expect.objectContaining({
         __v: 0,
-        _id: updated?._id,
-        name: updated?.name,
-        role: updated?.role,
+        _id: created._id,
+        name: 'John Doe',
+        role: 'manager',
         createdAt: created.createdAt
       }),
       patch: expect.arrayContaining([
+        { op: 'test', path: '/name', value: 'Bob' },
+        { op: 'replace', path: '/name', value: 'John Doe' },
         { op: 'test', path: '/role', value: 'user' },
-        { op: 'replace', path: '/role', value: 'manager' },
-        { op: 'test', path: '/name', value: 'John' },
-        { op: 'replace', path: '/name', value: 'John Doe' }
+        { op: 'replace', path: '/role', value: 'manager' }
       ])
     })
   })


### PR DESCRIPTION
Added missing update MongooseQueryMiddleware
- replaceOne
- findOneAndReplace
- findByIdAndUpdate

Added  missing delete MongooseQueryMiddleware
- findByIdAndDelete
- findByIdAndRemove

Two constants updateMethods, deleteMethods
Coverage for all above + some { upsert: true } creation cases