### PR TITLE
Ignore options

### DIFF
--- a/src/interfaces/IContext.ts
+++ b/src/interfaces/IContext.ts
@@ -7,6 +7,8 @@ interface IContext<T> {
   isNew?: boolean
   createdDocs?: HydratedDocument<T>[]
   deletedDocs?: HydratedDocument<T>[]
+  ignoreEvent?: boolean
+  ignorePatchHistory?: boolean
 }
 
 export default IContext

--- a/src/interfaces/IEvent.ts
+++ b/src/interfaces/IEvent.ts
@@ -1,0 +1,9 @@
+import type { Operation } from 'fast-json-patch'
+
+interface IEvent<T> {
+  oldDoc?: T
+  doc?: T
+  patch?: Operation[]
+}
+
+export default IEvent

--- a/src/interfaces/IEvent.ts
+++ b/src/interfaces/IEvent.ts
@@ -1,8 +1,9 @@
 import type { Operation } from 'fast-json-patch'
+import type { HydratedDocument } from 'mongoose'
 
 interface IEvent<T> {
-  oldDoc?: T
-  doc?: T
+  oldDoc?: HydratedDocument<T>
+  doc?: HydratedDocument<T>
   patch?: Operation[]
 }
 

--- a/tests/em.test.ts
+++ b/tests/em.test.ts
@@ -1,3 +1,4 @@
+import { emitEvent } from '../src/patch'
 import { patchEventEmitter } from '../src/plugin'
 
 describe('em', () => {
@@ -12,5 +13,38 @@ describe('em', () => {
     patchEventEmitter.off('test', fn)
     patchEventEmitter.emit('test')
     expect(count).toBe(1)
+  })
+
+  it('emitEvent', async () => {
+    const fn = jest.fn()
+    patchEventEmitter.on('test', fn)
+
+    const context = {
+      op: 'test',
+      modelName: 'Test',
+      collectionName: 'tests'
+    }
+
+    emitEvent(context, 'test', { doc: { name: 'test' } })
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    patchEventEmitter.off('test', fn)
+  })
+
+  it('emitEvent ignore', async () => {
+    const fn = jest.fn()
+    patchEventEmitter.on('test', fn)
+
+    const context = {
+      ignoreEvent: true,
+      op: 'test',
+      modelName: 'Test',
+      collectionName: 'tests'
+    }
+
+    emitEvent(context, 'test', { doc: { name: 'test' } })
+    expect(fn).toHaveBeenCalledTimes(0)
+
+    patchEventEmitter.off('test', fn)
   })
 })


### PR DESCRIPTION
- Added ignoreEvent & ignorePatchHistory so you can ignore history persisting or events emits on specific query when providing QueryOptions