### PR TITLE
type check this in the save hook to ignore EmbeddDocuments

### DIFF
--- a/src/hooks/save-hooks.ts
+++ b/src/hooks/save-hooks.ts
@@ -7,6 +7,9 @@ import type IContext from '../interfaces/IContext'
 
 export const saveHooksInitialize = <T>(schema: Schema<T>, opts: IPluginOptions<T>): void => {
   schema.pre('save', async function () {
+    if(this.constructor.name !== "model")
+        return
+
     const current = this.toObject(toObjectOptions) as HydratedDocument<T>
     const model = this.constructor as Model<T>
 


### PR DESCRIPTION
Solves the issue #182 by checking if `this.constructor` is a model in the pre save hook.