### PR TITLE
TTL for history collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ BookSchema.plugin(patchHistoryPlugin, {
   eventCreated: BOOK_CREATED,
   eventUpdated: BOOK_UPDATED,
   eventDeleted: BOOK_DELETED,
+
+  // You can set historyTTL in plain english or in milliseconds as you wish. This will determine how long you want to keep patch history.
+  // You don't need to use this option in case you want to keep patch history forever.
+  historyTTL: '1 month',
   
   // You can omit some properties in case you don't want to save them to patch history
   omit: ['__v', 'createdAt', 'updatedAt'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "fast-json-patch": "3.1.1",
         "lodash": "4.17.21",
+        "ms": "2.1.3",
         "omit-deep": "0.3.0",
         "power-assign": "0.2.10",
         "semver": "7.6.3"
@@ -18,6 +19,7 @@
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/lodash": "4.17.13",
+        "@types/ms": "0.7.34",
         "@types/node": "22.10.1",
         "@types/semver": "7.5.8",
         "@vitest/coverage-v8": "2.1.8",
@@ -2504,6 +2506,13 @@
       "integrity": "sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg==",
       "dev": true
     },
+    "node_modules/@types/ms": {
+      "version": "0.7.34",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
+      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.10.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
@@ -3806,7 +3815,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   "dependencies": {
     "fast-json-patch": "3.1.1",
     "lodash": "4.17.21",
+    "ms": "2.1.3",
     "omit-deep": "0.3.0",
     "power-assign": "0.2.10",
     "semver": "7.6.3"
@@ -84,6 +85,7 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@types/lodash": "4.17.13",
+    "@types/ms": "0.7.34",
     "@types/node": "22.10.1",
     "@types/semver": "7.5.8",
     "@vitest/coverage-v8": "2.1.8",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -44,9 +44,10 @@ export const useTTL = async <T>(opts: IPluginOptions<T>) => {
     if (existingIndex) {
       // Drop the existing index if it exists and TTL is different
       await History.collection.dropIndex(name)
-      // Create a new index with the correct TTL
-      await History.collection.createIndex({ createdAt: 1 }, { expireAfterSeconds, name })
     }
+
+    // Create a new index with the correct TTL if it doesn't exist or if the TTL is different
+    await History.collection.createIndex({ createdAt: 1 }, { expireAfterSeconds, name })
   } catch (err) {
     console.error("Couldn't create or update index for history collection", err)
   }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -15,39 +15,39 @@ export const toObjectOptions: ToObjectOptions = {
 }
 
 export const useTTL = async <T>(opts: IPluginOptions<T>) => {
-  const name = 'createdAt_1_TTL'; // To avoid collision with user defined index / manually created index
+  const name = 'createdAt_1_TTL' // To avoid collision with user defined index / manually created index
   try {
-    const indexes = await History.collection.indexes();
-    const existingIndex = indexes?.find(index => index.name === name);
+    const indexes = await History.collection.indexes()
+    const existingIndex = indexes?.find((index) => index.name === name)
 
     // Drop the index if historyTTL is not set and index exists
     if (!opts.historyTTL && existingIndex) {
-      await History.collection.dropIndex(name);
-      return;
+      await History.collection.dropIndex(name)
+      return
     }
 
-    const milliseconds = ms(opts.historyTTL as string);
+    const milliseconds = ms(opts.historyTTL as string)
 
     // Drop the index if historyTTL is less than 1 second and index exists
     if (milliseconds < 1000 && existingIndex) {
-      await History.collection.dropIndex(name);
-      return;
+      await History.collection.dropIndex(name)
+      return
     }
 
-    const expireAfterSeconds = milliseconds / 1000;
+    const expireAfterSeconds = milliseconds / 1000
 
     if (existingIndex && existingIndex.expireAfterSeconds === expireAfterSeconds) {
       // Index already exists with the correct TTL, no need to recreate
-      return;
+      return
     }
 
     if (existingIndex) {
       // Drop the existing index if it exists and TTL is different
-      await History.collection.dropIndex(name);
+      await History.collection.dropIndex(name)
       // Create a new index with the correct TTL
-      await History.collection.createIndex({ createdAt: 1 }, { expireAfterSeconds, name });
+      await History.collection.createIndex({ createdAt: 1 }, { expireAfterSeconds, name })
     }
   } catch (err) {
-    console.error("Couldn't create or update index for history collection", err);
+    console.error("Couldn't create or update index for history collection", err)
   }
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,9 @@
+import ms from 'ms'
+
+import History from './models/History'
+
 import type { QueryOptions, ToObjectOptions } from 'mongoose'
+import type IPluginOptions from './interfaces/IPluginOptions'
 
 export const isHookIgnored = <T>(options: QueryOptions<T>): boolean => {
   return options.ignoreHook === true || (options.ignoreEvent === true && options.ignorePatchHistory === true)
@@ -7,4 +12,42 @@ export const isHookIgnored = <T>(options: QueryOptions<T>): boolean => {
 export const toObjectOptions: ToObjectOptions = {
   depopulate: true,
   virtuals: false,
+}
+
+export const useTTL = async <T>(opts: IPluginOptions<T>) => {
+  const name = 'createdAt_1_TTL'; // To avoid collision with user defined index / manually created index
+  try {
+    const indexes = await History.collection.indexes();
+    const existingIndex = indexes?.find(index => index.name === name);
+
+    // Drop the index if historyTTL is not set and index exists
+    if (!opts.historyTTL && existingIndex) {
+      await History.collection.dropIndex(name);
+      return;
+    }
+
+    const milliseconds = ms(opts.historyTTL as string);
+
+    // Drop the index if historyTTL is less than 1 second and index exists
+    if (milliseconds < 1000 && existingIndex) {
+      await History.collection.dropIndex(name);
+      return;
+    }
+
+    const expireAfterSeconds = milliseconds / 1000;
+
+    if (existingIndex && existingIndex.expireAfterSeconds === expireAfterSeconds) {
+      // Index already exists with the correct TTL, no need to recreate
+      return;
+    }
+
+    if (existingIndex) {
+      // Drop the existing index if it exists and TTL is different
+      await History.collection.dropIndex(name);
+      // Create a new index with the correct TTL
+      await History.collection.createIndex({ createdAt: 1 }, { expireAfterSeconds, name });
+    }
+  } catch (err) {
+    console.error("Couldn't create or update index for history collection", err);
+  }
 }

--- a/src/interfaces/IPluginOptions.ts
+++ b/src/interfaces/IPluginOptions.ts
@@ -4,6 +4,7 @@ export type User = Record<string, unknown>
 export type Metadata = Record<string, unknown>
 
 interface IPluginOptions<T> {
+  historyTTL?: number | string
   modelName?: string
   collectionName?: string
   eventUpdated?: string

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,10 +1,7 @@
 import _ from 'lodash'
-import ms from 'ms'
 import em from './em'
 
-import History from './models/History'
-
-import { toObjectOptions } from './helpers'
+import { toObjectOptions, useTTL } from './helpers'
 import { createPatch, deletePatch } from './patch'
 import { isMongooseLessThan7, isMongooseLessThan8 } from './version'
 
@@ -30,19 +27,8 @@ export const patchEventEmitter = em
  * @returns {void}
  */
 export const patchHistoryPlugin = function plugin<T>(schema: Schema<T>, opts: IPluginOptions<T>): void {
-  // If opts historyTTL is set than index is created
-  const name = 'createdAt_1_TTL' // To avoid collision with user defined index / manually created index
-  if (opts.historyTTL != null) {
-    const expireAfterSeconds = ms(opts.historyTTL as string) / 1000
-    History.collection.createIndex({ createdAt: 1 }, { expireAfterSeconds, name }).catch((err) => {
-      console.error("Couldn't create index for history collection", err)
-    })
-  } else {
-    // Lets remove the index if it exists and we changed the mind about historyTTL
-    History.collection.dropIndex(name).catch((err) => {
-      console.error("Couldn't drop index for history collection", err)
-    })
-  }
+  // Create TTL index for history collection
+  useTTL(opts)
 
   // Initialize hooks
   saveHooksInitialize(schema, opts)

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -1,12 +1,14 @@
-import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
-import { useTTL } from '../src/helpers'
-import History from '../src/models/History'
 import ms from 'ms'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import History from '../src/models/History'
+
+import { useTTL } from '../src/helpers'
 
 import type { Mock, MockInstance } from 'vitest'
 
 vi.mock('../src/models/History', () => ({
-  default: { 
+  default: {
     collection: {
       indexes: vi.fn(),
       dropIndex: vi.fn(),
@@ -66,7 +68,7 @@ describe('useTTL', () => {
 
     const expireAfterSecondsBefore = ms(ttlBefore) / 1000
     const expireAfterSecondsAfter = ms(ttlAfter) / 1000
-  
+
     indexes.mockResolvedValue([{ name, expireAfterSeconds: expireAfterSecondsBefore }])
     const opts = { historyTTL: ttlAfter }
 
@@ -77,7 +79,7 @@ describe('useTTL', () => {
 
   it('should create the index if it does not exist', async () => {
     const opts = { historyTTL: '1h' }
-    const expireAfterSeconds = ms(opts.historyTTL) / 1000;
+    const expireAfterSeconds = ms(opts.historyTTL) / 1000
 
     indexes.mockResolvedValue([])
 

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { useTTL } from '../src/helpers'
+import History from '../src/models/History'
+import ms from 'ms'
+
+import type { Mock, MockInstance } from 'vitest'
+
+vi.mock('../src/models/History', () => ({
+  default: { 
+    collection: {
+      indexes: vi.fn(),
+      dropIndex: vi.fn(),
+      createIndex: vi.fn(),
+    },
+  },
+}))
+
+const name = 'createdAt_1_TTL'
+
+describe('useTTL', () => {
+  let dropIndexSpy: MockInstance
+  let createIndexSpy: MockInstance
+  const indexes = History.collection.indexes as Mock
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    dropIndexSpy = vi.spyOn(History.collection, 'dropIndex')
+    createIndexSpy = vi.spyOn(History.collection, 'createIndex')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should drop the index if historyTTL is not set and index exists', async () => {
+    indexes.mockResolvedValue([{ name }])
+    const opts = { historyTTL: undefined }
+
+    await useTTL(opts)
+    expect(dropIndexSpy).toHaveBeenCalledWith(name)
+  })
+
+  it('should drop the index if historyTTL is less than 1 second and index exists', async () => {
+    indexes.mockResolvedValue([{ name }])
+    const opts = { historyTTL: '500ms' }
+
+    await useTTL(opts)
+    expect(dropIndexSpy).toHaveBeenCalledWith(name)
+  })
+
+  it('should not recreate the index if it already exists with the correct TTL', async () => {
+    const ttl = '1h'
+    const expireAfterSeconds = ms(ttl) / 1000
+
+    indexes.mockResolvedValue([{ name, expireAfterSeconds }])
+    const opts = { historyTTL: ttl }
+
+    await useTTL(opts)
+    expect(dropIndexSpy).not.toHaveBeenCalled()
+    expect(createIndexSpy).not.toHaveBeenCalled()
+  })
+
+  it('should drop and recreate the index if TTL is different', async () => {
+    const ttlBefore = '1h'
+    const ttlAfter = '2h'
+
+    const expireAfterSecondsBefore = ms(ttlBefore) / 1000
+    const expireAfterSecondsAfter = ms(ttlAfter) / 1000
+  
+    indexes.mockResolvedValue([{ name, expireAfterSeconds: expireAfterSecondsBefore }])
+    const opts = { historyTTL: ttlAfter }
+
+    await useTTL(opts)
+    expect(dropIndexSpy).toHaveBeenCalledWith(name)
+    expect(createIndexSpy).toHaveBeenCalledWith({ createdAt: 1 }, { expireAfterSeconds: expireAfterSecondsAfter, name })
+  })
+
+  it('should create the index if it does not exist', async () => {
+    const opts = { historyTTL: '1h' }
+    const expireAfterSeconds = ms(opts.historyTTL) / 1000;
+
+    indexes.mockResolvedValue([])
+
+    await useTTL(opts)
+    expect(createIndexSpy).toHaveBeenCalledWith({ createdAt: 1 }, { expireAfterSeconds, name })
+  })
+})


### PR DESCRIPTION
This pull request includes changes to the `patchHistoryPlugin` to support a new `historyTTL` option, which allows users to set a time-to-live for patch history. Additionally, it introduces the `ms` package for time parsing and updates the `package.json` dependencies.