### PR TITLE
chore: pin fast-check in lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@biomejs/biome": "2.4.11",
         "@types/node": "25.6.0",
         "@vitest/coverage-v8": "4.1.4",
-        "fast-check": "^4.6.0",
+        "fast-check": "4.6.0",
         "mongodb-memory-server": "11.0.1",
         "mongoose": "9.4.1",
         "np": "11.0.3",


### PR DESCRIPTION
## Summary

`fast-check` was sitting as `^4.6.0` in `package-lock.json` while `package.json` declares an exact pin `4.6.0`. Aligns the lock with the declared pin to keep reproducible installs.

## Test plan

- [ ] `npm ci` resolves without drift
- [ ] CI green