### PR TITLE
chore: SHA-pin actions except SLSA reusable workflow

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -30,14 +30,14 @@ jobs:
         mongoose-version: [mongoose@6.12.2, mongoose@7.6.4, mongoose@8.23.0, mongoose@9.4.1]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Disabling shallow clone is recommended for improving relevancy of reporting
           fetch-depth: 0
           persist-credentials: false
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -63,14 +63,14 @@ jobs:
         node-version: [24.x]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Disabling shallow clone is recommended for improving relevancy of reporting
           fetch-depth: 0
           persist-credentials: false
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -92,7 +92,7 @@ jobs:
 
       - name: Scan
         if: env.SONAR_TOKEN
-        uses: SonarSource/sonarqube-scan-action@v7.1.0
+        uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,12 +20,12 @@ jobs:
       tarball-name: ${{ steps.pack.outputs.tarball-name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24.x
           registry-url: https://registry.npmjs.org
@@ -64,7 +64,7 @@ jobs:
           echo "hashes=$hashes" >> "$GITHUB_OUTPUT"
 
       - name: Upload tarball artifact
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: npm-tarball
           path: ${{ steps.pack.outputs.tarball-name }}
@@ -81,6 +81,11 @@ jobs:
       actions: read       # reusable workflow introspects run metadata
       id-token: write     # OIDC token for Sigstore keyless signing
       contents: write     # upload .intoto.jsonl to the triggering release
+    # NOTE: intentionally tag-pinned, not SHA-pinned. The SLSA generator's
+    # generate-builder.sh rejects commit-SHA refs ("Invalid ref … Expected
+    # refs/tags/vX.Y.Z") because it downloads its prebuilt binary from the
+    # GitHub release assets attached to the tag. Every other action in this
+    # repo is SHA-pinned for Scorecard's Pinned-Dependencies check.
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: ${{ needs.build.outputs.hashes }}
@@ -95,13 +100,13 @@ jobs:
       id-token: write     # npm provenance attestation via OIDC trusted publisher
     steps:
       - name: Use Node.js
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24.x
           registry-url: https://registry.npmjs.org
 
       - name: Download tarball artifact
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: npm-tarball
 

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -29,12 +29,12 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
@@ -44,6 +44,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v4.35.1
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- Re-SHA-pin all 13 direct GitHub Action references with trailing `# vX.Y.Z` comments. Restores Scorecard's Pinned-Dependencies check to high score after #361 switched everything to tag refs for readability.
- Leave `slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0` as a tag ref — it's the one action that *cannot* be SHA-pinned, because its `generate-builder.sh` fetches a prebuilt binary from the GitHub release assets attached to the tag. Pinning to a commit SHA fails with `Invalid ref ... Expected refs/tags/vX.Y.Z`, which is exactly what broke the first v4.0.0 release.
- Add an inline `NOTE` above the SLSA `uses:` so future supply-chain audits don't "helpfully" re-pin it and break the next release.

Escape hatch for future purist mode: set `compile-generator: true` on the SLSA job and SHA-pin it — adds ~2 min, bypasses the release-asset fetch. Not worth the fragility tradeoff right now.

## Test plan

- [ ] Scorecard Pinned-Dependencies check reports back at ~9–10 after next scan
- [ ] Next release triggers `publish.yaml` and provenance job still succeeds (the one tag-pinned workflow is the exact same one that worked on v4.0.0 after the recut)