### PR TITLE
Dual-sidecar release assets + scorecard-after-publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Build, attest, and pack
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write             # upload the attestation sidecars to the triggering release
       id-token: write             # OIDC token for Sigstore keyless signing
       attestations: write         # persist the build provenance attestation
       artifact-metadata: write    # create the artifact storage record that backs the attestation
@@ -63,9 +63,64 @@ jobs:
         # actions/attest is the canonical action per the docs; actions/attest-build-provenance
         # is now a thin wrapper around it. Default predicate type is SLSA v1 build provenance,
         # which is what we want for npm tarballs — no extra inputs needed.
+        id: attest
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: ${{ steps.pack.outputs.tarball-name }}
+
+      - name: Attach attestation bundles to release
+        # SLSA v1.2 recommends publishing provenance in more than one channel.
+        # actions/attest already uploaded the Sigstore bundle to GitHub's native
+        # attestation store and npm ships an npm-registry provenance attestation
+        # via publishConfig.provenance: true. This step adds two more channels —
+        # both sidecar files on the GitHub Release carrying the same DSSE
+        # envelope at the innermost layer but in different outer containers
+        # for different verification flows:
+        #
+        # 1. <tarball>.sigstore.json — the full Sigstore bundle produced by
+        #    actions/attest (application/vnd.dev.sigstore.bundle.v0.3+json).
+        #    Includes the Fulcio certificate and the Rekor inclusion proof,
+        #    so consumers can verify offline without querying Rekor. Parsed
+        #    by `gh attestation verify --bundle` and other Sigstore-native
+        #    tooling.
+        #
+        # 2. <tarball>.intoto.jsonl — a spec-compliant in-toto attestation v1
+        #    bundle (https://github.com/in-toto/attestation/blob/main/spec/v1/bundle.md):
+        #    JSON Lines of DSSE envelopes, one envelope per line. Extracted
+        #    from the Sigstore bundle via `jq -c .dsseEnvelope` — NOT a
+        #    renamed Sigstore bundle. Verified by `slsa-verifier
+        #    verify-artifact`, which queries Rekor for the cert and
+        #    inclusion proof via the signature hash.
+        #
+        # Both files carry the same signature over the same SLSA v1 payload
+        # (predicateType https://slsa.dev/provenance/v1). The split is about
+        # serving two different consumer verification flows, not duplicating
+        # trust material. The `.intoto.jsonl` shape is also what OpenSSF
+        # Scorecard's `releasesHaveProvenance` probe looks for on the
+        # release-asset channel.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
+          TARBALL: ${{ steps.pack.outputs.tarball-name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          # 1. Full Sigstore bundle — straight copy of actions/attest output.
+          sigstore="${TARBALL}.sigstore.json"
+          cp "$BUNDLE_PATH" "$sigstore"
+
+          # 2. In-toto attestation bundle — JSON Lines of DSSE envelopes.
+          #    `jq -c` emits a single-line JSON object, which by definition
+          #    is also a valid one-line JSONL document. The Sigstore bundle's
+          #    dsseEnvelope field is already a standard DSSE envelope
+          #    (payload, payloadType, signatures) so no shape transformation
+          #    is needed beyond the projection.
+          intoto="${TARBALL}.intoto.jsonl"
+          jq -c '.dsseEnvelope' "$BUNDLE_PATH" > "$intoto"
+
+          gh release upload "$RELEASE_TAG" "$sigstore" "$intoto" \
+            --repo "$GITHUB_REPOSITORY" --clobber
 
       - name: Upload tarball artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -13,6 +13,14 @@ on:
     - cron: '32 7 * * 1'
   push:
     branches: [ "main" ]
+  # Re-score after every successful Publish run so the Signed-Releases check
+  # sees the freshly attached release-asset sidecars. Without this, the
+  # Scorecard scan from the pre-release push to main races the publish.yaml
+  # workflow and captures a stale state where release assets aren't yet
+  # uploaded.
+  workflow_run:
+    workflows: ["Publish"]
+    types: [completed]
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -21,6 +29,11 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    # When triggered by workflow_run (after Publish), only proceed if the
+    # Publish run actually succeeded. No point scoring a failed release.
+    # For all other triggers (push, schedule, branch_protection_rule) the
+    # condition evaluates true and the job runs normally.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write


### PR DESCRIPTION
## Summary

Close the gap between the `actions/attest@v4` pipeline (which only stores provenance in GitHub's native attestation store) and the classic release-asset distribution channel that many verifiers still look for. Two related workflow changes.

### 1. `publish.yaml` — dual attestation sidecars on release

[SLSA v1.2](https://slsa.dev/spec/v1.2/distributing-provenance) recommends publishing provenance in more than one channel. Currently the `actions/attest` step deposits a Sigstore bundle into GitHub's native attestation store and nothing else — no file on the release page. That leaves three verification paths unsupported:

- Consumers who want to verify offline via `gh attestation verify --bundle` can't find the bundle on the release.
- `slsa-verifier` users can't find an in-toto attestation bundle at all.
- OpenSSF Scorecard's `releasesHaveProvenance` probe (which looks for `*.intoto.jsonl` on release assets) sees nothing on new releases, so the `Signed-Releases` score will eventually drop from **10/10** (earned by legacy `.intoto.jsonl` files from the old `slsa-github-generator` pipeline) as the last-N window rolls over.

**Fix:** after `actions/attest` signs the tarball, upload **two** sidecar files:

1. **`<tarball>.sigstore.json`** — straight copy of the action's `bundle-path` output, a full [Sigstore v0.3 bundle](https://github.com/sigstore/protobuf-specs/blob/main/protos/sigstore_bundle.proto) (`application/vnd.dev.sigstore.bundle.v0.3+json`). Carries the Fulcio certificate and Rekor inclusion proof embedded inline — self-contained, verifiable offline via `gh attestation verify --bundle`.
2. **`<tarball>.intoto.jsonl`** — the DSSE envelope extracted from the Sigstore bundle via `jq -c '.dsseEnvelope'`. This is a spec-compliant [in-toto attestation v1 bundle](https://github.com/in-toto/attestation/blob/main/spec/v1/bundle.md) — JSON Lines of DSSE envelopes, one envelope per line — **not** a renamed Sigstore bundle. Verified by `slsa-verifier verify-artifact` via a Rekor lookup for the certificate and inclusion proof.

Both files carry the same signature over the same SLSA v1 payload (`predicateType: https://slsa.dev/provenance/v1`). The split is about serving two different consumer verification flows, not duplicating trust material.

Requires `contents: write` on the build job (was `contents: read`) so `gh release upload` can attach the sidecars.

### 2. `scorecard.yaml` — re-score after successful Publish

Add a `workflow_run` trigger so Scorecard re-scans after every successful Publish run. Without this, the Scorecard scan from the pre-release push-to-main merge fires **before** `publish.yaml` finishes uploading release-asset sidecars, capturing a stale state where the just-released version looks like a source-only release.

Typical timing on a release:

```
T+0s    release tag created, publish.yaml starts
T+~7s   push-to-main-triggered Scorecard scan runs, sees the new
        release as source-only (assets not yet attached)
T+~60s  publish.yaml finishes attaching both sidecars
```

The new `workflow_run` trigger catches the release state **after** `publish.yaml` completes, when the assets are actually visible:

```yaml
on:
  branch_protection_rule:
  schedule:
    - cron: '32 7 * * 1'
  push:
    branches: ["main"]
  workflow_run:
    workflows: ["Publish"]
    types: [completed]
```

Plus an `if:` guard on the analysis job so `workflow_run`-triggered scans only run when the upstream Publish succeeded:

```yaml
if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
```

For the existing triggers (`push`, `schedule`, `branch_protection_rule`) the guard evaluates true and the job runs as before.

`push: main` stays in place — it covers every merge to main including those between releases, which `workflow_run: Publish` doesn't.

### Trigger matrix after this change

| Trigger | Fires on | Purpose |
|---|---|---|
| `branch_protection_rule` | Ruleset changes | Re-check Branch-Protection |
| `schedule` (Mon 07:32 UTC) | Weekly | Belt-and-braces fallback, externally-changing checks |
| `push: main` | Every merge | Catches between-release changes |
| **`workflow_run: Publish`** (new) | After every Publish | Fresh Signed-Releases scoring post-release |

## Test plan

- [x] Both files parse as YAML
- [x] Same dual-sidecar workflow shape validated end-to-end on another project before this PR — confirmed that `gh attestation verify --bundle` against the downloaded `.sigstore.json` returns exit 0 and that `jq` extraction produces a 1-line JSONL whose DSSE payload decodes to a valid in-toto v1 Statement with `predicateType: https://slsa.dev/provenance/v1` and `builder.id` pinned to `.github/workflows/publish.yaml@refs/tags/<tag>`
- [ ] Next release cut under the updated pipeline — observe both sidecars on the Release page and a Scorecard scan firing after Publish completes
- [ ] `gh attestation verify --bundle ts-patch-mongoose-X.Y.Z.tgz.sigstore.json --repo ilovepixelart/ts-patch-mongoose --signer-workflow ilovepixelart/ts-patch-mongoose/.github/workflows/publish.yaml` → exit 0
- [ ] `slsa-verifier verify-artifact ts-patch-mongoose-X.Y.Z.tgz --provenance-path ts-patch-mongoose-X.Y.Z.tgz.intoto.jsonl --source-uri github.com/ilovepixelart/ts-patch-mongoose --source-tag vX.Y.Z` → exit 0
- [ ] Post-publish Scorecard scan sees the `.intoto.jsonl` and keeps `Signed-Releases` at 10/10